### PR TITLE
Drop the stale ENABLE_WATCHOS comment from the CI workflow

### DIFF
--- a/.github/workflows/SwiftTube.yml
+++ b/.github/workflows/SwiftTube.yml
@@ -165,9 +165,6 @@ jobs:
   # Full Apple-platform suite (iOS/watchOS/tvOS) on Swift 6.4, on the GitHub-hosted
   # xcode-27 runner with downloadable 27.0 simulator runtimes. Blocking leg; simulator runs on the nightly
   # toolchain are the most fragile leg. Bump deviceName/osVersion as Xcode-beta moves.
-  # The watchOS leg is gated on the ENABLE_WATCHOS repo variable (set 'false' to skip it
-  # where the watchOS-27 SDK rejects deps inferring 8.0 — SwiftPM #10188; see
-  # brightdigit.com#119). iOS/tvOS always run.
   build-macos-platforms:
     name: Build on macOS (Platforms)
     needs: configure


### PR DESCRIPTION
`build-macos-platforms` is documented as gating the watchOS leg on an `ENABLE_WATCHOS` repo variable (citing SwiftPM #10188 / brightdigit.com#119). No such gate exists in this workflow — nothing references `vars.ENABLE_WATCHOS`, and the watchOS row runs unconditionally alongside iOS and tvOS.

Comment-only change — no step, action, or matrix row is modified.

Found while auditing the CI template across the package fleet. The same stale comment was present in Contribute (brightdigit/Contribute#18), Plot, Files, Ink, SwiftTube, Spinetail, and all seven Wave 1 packages; this is the `SwiftTube` half of that sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)